### PR TITLE
[Feat] basic configuration 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	compileOnly 'org.projectlombok:lombok'
@@ -29,8 +30,31 @@ dependencies {
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.8'
+
+	// Querydsl 추가 (Spring boot 3.x 이상)
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// querydsl 추가 시작
+def querydslDir = "src/main/generated"
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
+}
+// querydsl 추가 끝

--- a/src/main/java/server/meeting/domain/meeting/model/Meeting.java
+++ b/src/main/java/server/meeting/domain/meeting/model/Meeting.java
@@ -1,0 +1,56 @@
+package server.meeting.domain.meeting.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import server.meeting.domain.member.model.Member;
+import server.meeting.global.common.BaseEntity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Meeting extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meetingId")
+    private Long id;
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @Size(min = 8, max = 12)
+    @Column(length = 10, nullable = false)
+    private LocalDate date;
+
+    @NotNull
+    @Size(max = 3)
+    @Column(length = 5, nullable = false)
+    private String day;
+
+    @NotNull
+    @Size(max = 1000)
+    @Column(length = 1000)
+    private String extraContent;
+
+    @NotNull
+    @Size(max = 5000)
+    @Column(length = 5000, nullable = false)
+    private String summary;
+
+    @NotNull
+    @Size(max = 500)
+    @Column(length = 500)
+    private String recommendKeyword;
+
+    @OneToMany(mappedBy = "meetingId", fetch = FetchType.LAZY)
+    private List<Member> participants = new ArrayList<>();
+
+}

--- a/src/main/java/server/meeting/domain/meeting/model/Meeting.java
+++ b/src/main/java/server/meeting/domain/meeting/model/Meeting.java
@@ -17,22 +17,23 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "MEETING")
 public class Meeting extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "meetingId")
+    @Column(name = "meeting_id")
     private Long id;
 
     @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Size(min = 8, max = 12)
-    @Column(length = 10, nullable = false)
+    @Column(name = "date_column", length = 10, nullable = false)
     private LocalDate date;
 
     @NotNull
     @Size(max = 3)
-    @Column(length = 5, nullable = false)
+    @Column(name = "day_column", length = 5, nullable = false)
     private String day;
 
     @NotNull
@@ -50,7 +51,7 @@ public class Meeting extends BaseEntity {
     @Column(length = 500)
     private String recommendKeyword;
 
-    @OneToMany(mappedBy = "meetingId", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "meeting")
     private List<Member> participants = new ArrayList<>();
 
 }

--- a/src/main/java/server/meeting/domain/member/model/Member.java
+++ b/src/main/java/server/meeting/domain/member/model/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.meeting.domain.meeting.model.Meeting;
 import server.meeting.domain.team.model.Team;
 import server.meeting.global.common.BaseEntity;
 
@@ -26,5 +27,7 @@ public class Member extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Meeting meeting;
 
 }

--- a/src/main/java/server/meeting/domain/record/model/Record.java
+++ b/src/main/java/server/meeting/domain/record/model/Record.java
@@ -1,0 +1,45 @@
+package server.meeting.domain.record.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+import org.springframework.context.annotation.Lazy;
+import server.meeting.domain.meeting.model.Meeting;
+import server.meeting.global.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Record extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Size(max = 300)
+    @Column(length = 300, nullable = false)
+    private String fileName;
+
+    @NotNull
+    @Size(max = 100)
+    @Column(length = 100, nullable = false)
+    private String originalFileName;
+
+    @NotNull
+    @Column(length = 2083, nullable = false)
+    private String recordFile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meetingId")
+    private Meeting meeting;
+
+    public Record(String fileName, String originalFileName, String recordFile) {
+        this.fileName = fileName;
+        this.originalFileName = originalFileName;
+        this.recordFile = recordFile;
+    }
+}

--- a/src/main/java/server/meeting/domain/record/model/Record.java
+++ b/src/main/java/server/meeting/domain/record/model/Record.java
@@ -35,7 +35,7 @@ public class Record extends BaseEntity {
     private String recordFile;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "meetingId")
+    @JoinColumn(name = "meeting_id")
     private Meeting meeting;
 
     @Builder

--- a/src/main/java/server/meeting/domain/record/model/Record.java
+++ b/src/main/java/server/meeting/domain/record/model/Record.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
@@ -37,9 +38,12 @@ public class Record extends BaseEntity {
     @JoinColumn(name = "meetingId")
     private Meeting meeting;
 
+    @Builder
     public Record(String fileName, String originalFileName, String recordFile) {
-        this.fileName = fileName;
-        this.originalFileName = originalFileName;
-        this.recordFile = recordFile;
+        Record.builder()
+                .fileName(fileName)
+                .originalFileName(originalFileName)
+                .recordFile(recordFile)
+                .build();
     }
 }

--- a/src/main/java/server/meeting/global/api/Api.java
+++ b/src/main/java/server/meeting/global/api/Api.java
@@ -1,0 +1,50 @@
+package server.meeting.global.api;
+
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import server.meeting.global.error.ErrorCodeInterface;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Api<T> {
+
+    private Result result;
+
+    @Valid
+    private T body;
+
+    public static <T> Api<T> success(T data) {
+        Api<T> api = new Api<T>();
+        api.result = Result.OK();
+        api.body = data;
+        return api;
+    }
+
+    public static <T> Api<T> ERROR(Result result) {
+        Api<T> api = new Api<T>();
+        api.result = result;
+        return api;
+    }
+
+    public static <T> Api<T> ERROR(Result result, ErrorCodeInterface errorCode) {
+        Api<T> api = new Api<T>();
+        api.result = Result.ERROR(errorCode);
+        return api;
+    }
+
+    public static <T> Api<T> ERROR(Result result, ErrorCodeInterface errorCode, Throwable tx) {
+        Api<T> api = new Api<T>();
+        api.result = Result.ERROR(errorCode, tx);
+        return api;
+    }
+
+    public static <T> Api<T> ERROR(Result result, ErrorCodeInterface errorCode, String description) {
+        Api<T> api = new Api<T>();
+        api.result = Result.ERROR(errorCode, description);
+        return api;
+    }
+}

--- a/src/main/java/server/meeting/global/api/Api.java
+++ b/src/main/java/server/meeting/global/api/Api.java
@@ -1,13 +1,11 @@
 package server.meeting.global.api;
 
 import jakarta.validation.Valid;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import server.meeting.global.error.ErrorCodeInterface;
 
-@Data
+@Getter
+@ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Api<T> {

--- a/src/main/java/server/meeting/global/api/Result.java
+++ b/src/main/java/server/meeting/global/api/Result.java
@@ -1,0 +1,49 @@
+package server.meeting.global.api;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+import server.meeting.global.error.ErrorCodeInterface;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Result {
+
+    private Integer resultCode;
+    private String resultMessage;
+    private String resultDescription;
+
+    public static Result OK() {
+        return Result.builder()
+                .resultCode(200)
+                .resultMessage("OK")
+                .resultDescription("성공하였습니다.")
+                .build();
+    }
+
+    public static Result ERROR(ErrorCodeInterface errorCodeInterface){
+        return Result.builder()
+                .resultCode(errorCodeInterface.getStatus())
+                .resultMessage(errorCodeInterface.getErrorCode())
+                .resultDescription("오류가 발생하였습니다.")
+                .build();
+    }
+
+    public static Result ERROR(ErrorCodeInterface errorCodeInterface, Throwable tx){
+        return Result.builder()
+                .resultCode(errorCodeInterface.getStatus())
+                .resultMessage(errorCodeInterface.getDescription())
+                .resultDescription(tx.getLocalizedMessage())
+                .build();
+    }
+
+    public static Result ERROR(ErrorCodeInterface errorCodeInterface, String description){
+        return Result.builder()
+                .resultCode(errorCodeInterface.getStatus())
+                .resultMessage(errorCodeInterface.getErrorCode())
+                .resultDescription(errorCodeInterface.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/server/meeting/global/api/Result.java
+++ b/src/main/java/server/meeting/global/api/Result.java
@@ -25,7 +25,7 @@ public class Result {
 
     public static Result ERROR(ErrorCodeInterface errorCodeInterface){
         return Result.builder()
-                .resultCode(errorCodeInterface.getStatus())
+                .resultCode(errorCodeInterface.getStatus().value())
                 .resultMessage(errorCodeInterface.getErrorCode())
                 .resultDescription("오류가 발생하였습니다.")
                 .build();
@@ -33,7 +33,7 @@ public class Result {
 
     public static Result ERROR(ErrorCodeInterface errorCodeInterface, Throwable tx){
         return Result.builder()
-                .resultCode(errorCodeInterface.getStatus())
+                .resultCode(errorCodeInterface.getStatus().value())
                 .resultMessage(errorCodeInterface.getDescription())
                 .resultDescription(tx.getLocalizedMessage())
                 .build();
@@ -41,7 +41,7 @@ public class Result {
 
     public static Result ERROR(ErrorCodeInterface errorCodeInterface, String description){
         return Result.builder()
-                .resultCode(errorCodeInterface.getStatus())
+                .resultCode(errorCodeInterface.getStatus().value())
                 .resultMessage(errorCodeInterface.getErrorCode())
                 .resultDescription(errorCodeInterface.getDescription())
                 .build();

--- a/src/main/java/server/meeting/global/error/ErrorCodeInterface.java
+++ b/src/main/java/server/meeting/global/error/ErrorCodeInterface.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public interface ErrorCodeInterface {
 
-    Integer getStatus();
+    HttpStatus getStatus();
     String getErrorCode();
     String getDescription();
 }

--- a/src/main/java/server/meeting/global/error/ErrorCodeInterface.java
+++ b/src/main/java/server/meeting/global/error/ErrorCodeInterface.java
@@ -1,0 +1,10 @@
+package server.meeting.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCodeInterface {
+
+    Integer getStatus();
+    String getErrorCode();
+    String getDescription();
+}

--- a/src/main/java/server/meeting/global/error/ErrorType.java
+++ b/src/main/java/server/meeting/global/error/ErrorType.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 import static org.springframework.http.HttpStatus.OK;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public enum ErrorType implements ErrorCodeInterface {
 
     _OK(OK, "200", "성공");

--- a/src/main/java/server/meeting/global/error/ErrorType.java
+++ b/src/main/java/server/meeting/global/error/ErrorType.java
@@ -1,0 +1,21 @@
+package server.meeting.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ErrorType implements ErrorCodeInterface {
+
+    _OK(OK, "200", "성공");
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String description;
+
+
+}

--- a/src/main/java/server/meeting/global/exception/ApiException.java
+++ b/src/main/java/server/meeting/global/exception/ApiException.java
@@ -1,0 +1,35 @@
+package server.meeting.global.exception;
+
+import lombok.Getter;
+import server.meeting.global.error.ErrorCodeInterface;
+
+@Getter
+public class ApiException extends RuntimeException implements ApiExceptionInterface{
+
+    private final ErrorCodeInterface errorCodeInterface;
+    private final String errorDescription;
+
+    public ApiException(ErrorCodeInterface errorCodeInterface) {
+        super(errorCodeInterface.getDescription());
+        this.errorCodeInterface = errorCodeInterface;
+        this.errorDescription = errorCodeInterface.getDescription();
+    }
+
+    public ApiException(ErrorCodeInterface errorCodeInterface, String errorDescription) {
+        super(errorDescription);
+        this.errorCodeInterface = errorCodeInterface;
+        this.errorDescription = errorDescription;
+    }
+
+    public ApiException(ErrorCodeInterface errorCodeInterface, Throwable tx) {
+        super(tx);
+        this.errorCodeInterface = errorCodeInterface;
+        this.errorDescription = errorCodeInterface.getDescription();
+    }
+
+    public ApiException(ErrorCodeInterface errorCodeInterface, String errorDescription, Throwable tx) {
+        super(tx);
+        this.errorCodeInterface = errorCodeInterface;
+        this.errorDescription = errorDescription;
+    }
+}

--- a/src/main/java/server/meeting/global/exception/ApiExceptionInterface.java
+++ b/src/main/java/server/meeting/global/exception/ApiExceptionInterface.java
@@ -1,0 +1,9 @@
+package server.meeting.global.exception;
+
+import server.meeting.global.error.ErrorCodeInterface;
+
+public interface ApiExceptionInterface {
+
+    ErrorCodeInterface getErrorCodeInterface();
+    String getErrorDescription();
+}


### PR DESCRIPTION
## 무엇을?
> 프로젝트 진행에 있어서 필요한 기본적인 설정들을 구현한다.

## 작업 상세 내용

- [x] SuccessResponse 구현
- [x] Exception 커스텀 구현
- [x] Entity 생성
- [x] querydsl 세팅

## 참고 자료
1. Meeting과 Record에 대한 엔티티를 만들어 보았습니다.
- 이때 Sql 자료형 구조와 일치하는 day와 date로 인해 테이블이 생성되지 않는 오류가 있었는데 이를 잘 해결하였습니다.
<img width="487" alt="스크린샷 2024-11-19 오후 4 08 38" src="https://github.com/user-attachments/assets/74a33a44-2770-4865-8f96-da2fbf540d7f">

2. ApiResponse를 재구성하여 효과적으로 반환할 수 있도록 구현하였습니다.
<img width="569" alt="스크린샷 2024-11-19 오후 4 11 12" src="https://github.com/user-attachments/assets/9d6c23d7-1f3a-4aad-9509-93f8549858b0">
