### PR TITLE
[feat] S3 업로드 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/server/meeting/domain/meeting/model/Meeting.java
+++ b/src/main/java/server/meeting/domain/meeting/model/Meeting.java
@@ -51,7 +51,7 @@ public class Meeting extends BaseEntity {
     @Column(length = 500)
     private String recommendKeyword;
 
-    @OneToMany(mappedBy = "meeting")
-    private List<Member> participants = new ArrayList<>();
+    @OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<MeetingMembers> meetingMembers = new ArrayList<>();
 
 }

--- a/src/main/java/server/meeting/domain/meeting/model/Meeting.java
+++ b/src/main/java/server/meeting/domain/meeting/model/Meeting.java
@@ -51,7 +51,7 @@ public class Meeting extends BaseEntity {
     @Column(length = 500)
     private String recommendKeyword;
 
-    @OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "meeting")
     private List<MeetingMembers> meetingMembers = new ArrayList<>();
 
 }

--- a/src/main/java/server/meeting/domain/meeting/model/MeetingMembers.java
+++ b/src/main/java/server/meeting/domain/meeting/model/MeetingMembers.java
@@ -13,7 +13,6 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MeetingMembers {
 
     @Id

--- a/src/main/java/server/meeting/domain/meeting/model/MeetingMembers.java
+++ b/src/main/java/server/meeting/domain/meeting/model/MeetingMembers.java
@@ -1,0 +1,30 @@
+package server.meeting.domain.meeting.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.meeting.domain.member.model.Member;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingMembers {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/server/meeting/domain/member/model/Member.java
+++ b/src/main/java/server/meeting/domain/member/model/Member.java
@@ -5,8 +5,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.meeting.domain.meeting.model.Meeting;
+import server.meeting.domain.meeting.model.MeetingMembers;
 import server.meeting.domain.team.model.Team;
 import server.meeting.global.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,7 +31,7 @@ public class Member extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Meeting meeting;
+    @OneToMany(mappedBy = "member")
+    private List<MeetingMembers> meetingMembers = new ArrayList<>();
 
 }

--- a/src/main/java/server/meeting/global/config/jpaConfig/JpaConfig.java
+++ b/src/main/java/server/meeting/global/config/jpaConfig/JpaConfig.java
@@ -1,4 +1,4 @@
-package server.meeting.global.config.JpaConfig;
+package server.meeting.global.config.jpaConfig;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/server/meeting/global/error/ErrorType.java
+++ b/src/main/java/server/meeting/global/error/ErrorType.java
@@ -5,13 +5,18 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorType implements ErrorCodeInterface {
 
-    _OK(OK, "200", "성공");
+    _OK(OK, "200", "성공"),
+
+    // --------------------------------------- S3 -----------------------------------
+    _S3_UPLOAD_FAIL(BAD_REQUEST, "S4001", "업로드에 실패하였습니다."),
+    _S3_NOT_EXISTS_KEY(BAD_REQUEST, "S4002", "존재하지 않는 파일 명입니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/server/meeting/global/s3/S3Config.java
+++ b/src/main/java/server/meeting/global/s3/S3Config.java
@@ -1,0 +1,33 @@
+package server.meeting.global.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client(){
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/server/meeting/global/s3/S3Service.java
+++ b/src/main/java/server/meeting/global/s3/S3Service.java
@@ -1,0 +1,87 @@
+package server.meeting.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import server.meeting.global.error.ErrorType;
+import server.meeting.global.exception.ApiException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.UUID;
+
+@Component
+@Service
+public class S3Service {
+
+    private final String bucketName;
+    private final AmazonS3 amazonS3Client;
+
+    public S3Service(@Value("${cloud.aws.s3.bucket") String bucketName, AmazonS3 amazonS3Client) {
+        this.bucketName = bucketName;
+        this.amazonS3Client = amazonS3Client;
+    }
+
+    public URL uploadFile(MultipartFile file) {
+        String key = file.getOriginalFilename();
+        key = checkIfExists(key);
+
+        try (InputStream inputStream = file.getInputStream()) {
+            ObjectMetadata metadata = setMetaData(file);
+
+            PutObjectRequest request = new PutObjectRequest(bucketName, key, inputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3Client.putObject(request);
+            return getImageUrl(key);
+        } catch (IOException e) {
+            throw new ApiException(ErrorType._S3_NOT_EXISTS_KEY);
+        }
+    }
+
+    public void deleteImage(String key) {
+        try {
+            amazonS3Client.deleteObject(bucketName, key);
+        } catch (Exception e) {
+            throw new ApiException(ErrorType._S3_NOT_EXISTS_KEY);
+        }
+    }
+
+    public URL getImageUrl(String key) {
+        try {
+            return amazonS3Client.getUrl(bucketName, key);
+        } catch (Exception e) {
+            throw new ApiException(ErrorType._S3_NOT_EXISTS_KEY);
+        }
+    }
+
+    private ObjectMetadata setMetaData(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+        return metadata;
+    }
+
+    private String checkIfExists(String fileName) {
+        if(!StringUtils.hasText(fileName)) {
+            return UUID.randomUUID() + getFileExtension(fileName);
+        }
+        return fileName;
+    }
+
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        if(dotIndex > 0 && dotIndex < fileName.length() - 1) {
+            return fileName.substring(dotIndex);
+        }
+        return ""; // 확장자 없음
+    }
+}

--- a/src/test/java/server/meeting/global/s3/S3ServiceTest.java
+++ b/src/test/java/server/meeting/global/s3/S3ServiceTest.java
@@ -1,0 +1,42 @@
+package server.meeting.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @InjectMocks
+    private S3Service s3Service;
+
+    @DisplayName("s3에 정상적으로 업로드되는지 확인한다.")
+    @Test
+    void s3Upload() throws MalformedURLException {
+     //given
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "test", "test-image.jpg", "image/jpeg", "image content".getBytes()
+        );
+
+     //when
+
+     //then
+    }
+}


### PR DESCRIPTION
## 무엇을?
> 녹음본을 저장하기 위해 필요한 aws S3를 spring과 연동한다.

## 작업 상세 내용

- [x] S3 Config 구현
- [x] S3 uploadService 구현
- [x] Member와 Meeting 간의 연관관계 구현

## 참고 자료
1. Member와 Meeting 간의 다대다 관계를 위해 일대다-다대일 관계로 변경시켜 주었습니다.
- 다대다 관계를 바로 설정하지 않은 이유는 데이터 간의 중복이 일어나 데이터 무결성의 문제를 가져올 수 있습니다.
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/1b133482-7347-44db-bc86-3100658a1c39">
<img width="438" alt="image" src="https://github.com/user-attachments/assets/e2e7fdc1-1ed3-4591-ae5b-749c330ffd99">
